### PR TITLE
MinKNOW sequencing_summary filenames

### DIFF
--- a/artic/gather.py
+++ b/artic/gather.py
@@ -3,6 +3,7 @@ from Bio import SeqIO
 import tempfile
 import os
 import glob
+import fnmatch
 import shutil
 import pandas as pd
 from collections import defaultdict
@@ -43,7 +44,7 @@ def run(parser, args):
 			barcode_directory = paths[-1]
 
 			fastq[barcode_directory].extend([root+'/'+f for f in files if f.endswith('.fastq')])
-			summary_files.extend([root+'/'+f for f in files if f.find('_summary.txt') != -1])
+			summary_files.extend([root+'/'+f for f in files if fnmatch.fnmatch(f, '*cing_summary*txt')])
 
 	for barcode_directory, fastq in list(fastq.items()):
 		if len(fastq):


### PR DESCRIPTION
With MinKNOW the sequencing_summary filename includes both the flowcell id and run_id - this breaks artic workflow directly for e.g. GridION devices

The change here (first is the main branch) will fix an issue a couple of users have seen 