### PR TITLE
Support for Guppy-based demultiplexing

### DIFF
--- a/artic/guppyplex.py
+++ b/artic/guppyplex.py
@@ -1,0 +1,68 @@
+import sys
+from Bio import SeqIO
+import tempfile
+import os
+import glob
+import fnmatch
+import shutil
+import pandas as pd
+from collections import defaultdict
+from mimetypes import guess_type
+from functools import partial
+from math import log10
+from random import random
+
+# the ambition of this module is to merge some of the functionality from the "gather" and "demultiplex" tasks;
+# we are assuming the input is already guppy-demultiplexed data (one-pot barcoding - like) - this workflow will
+# also assume that Medaka rather than Nanopolish will be used and will skip the sequencing_summary step - basic
+# QC metrics will be derived during the fastq parsing step ...
+
+# This method will also allow for the analysis of gzipped fastq files = makes sense of space
+
+# Have tried to be minimally invasive to the existing code - maintain FieldBioinformatics style
+
+
+def get_read_mean_quality(record):
+	return -10 * log10((10 ** (pd.Series(record.letter_annotations["phred_quality"]) / -10)).mean())
+
+
+def run(parser, args):
+	fastq = defaultdict(list)
+	files = os.listdir(args.directory)
+	fastq[args.directory].extend([os.path.join(args.directory, f) for f in files if fnmatch.fnmatch(f, '*.fastq*')])
+
+	for barcode_directory, fastq in list(fastq.items()):
+		if len(fastq):
+			fastq_outfn = "%s_%s.fastq" % (args.prefix, os.path.basename(barcode_directory))
+			outfh = open(fastq_outfn, "w")
+			print("Processing %s files in %s" % (len(fastq), barcode_directory), file=sys.stderr)
+
+			dups = set()
+
+			for file in fastq:
+				encoding = guess_type(file)[1]
+				_open = open
+				# only accommodating gzip compression at present
+				if encoding == "gzip":
+					_open = partial(gzip.open, mode="rt")
+				with _open(file) as f:
+					for rec in SeqIO.parse(f, "fastq"):
+						if args.max_length and len(rec) > args.max_length:
+							continue
+						if args.min_length and len(rec) < args.min_length:
+							continue
+						if get_read_mean_quality(rec) >= args.quality:
+							continue
+						r = random()
+						if r >= args.sample:
+							print("incld")
+							continue
+
+						if rec.id not in dups:
+							SeqIO.write([rec], outfh, "fastq")
+							dups.add(rec.id)
+
+			outfh.close()
+			print(f"{fastq_outfn}\t{len(dups)}")
+
+

--- a/artic/guppyplex.py
+++ b/artic/guppyplex.py
@@ -55,7 +55,6 @@ def run(parser, args):
 							continue
 						r = random()
 						if r >= args.sample:
-							print("incld")
 							continue
 
 						if rec.id not in dups:

--- a/artic/pipeline.py
+++ b/artic/pipeline.py
@@ -27,6 +27,8 @@ def run_subtool(parser, args):
         from . import filter as submodule
     if args.command == 'run':
         from . import run as submodule
+    if args.command == 'guppyplex':
+        from . import guppyplex as submodule
 
     # run the chosen submodule.
     submodule.run(parser, args)
@@ -91,6 +93,19 @@ def main():
     parser_gather.add_argument('--prefix', help='Prefix for gathered files')
     parser_gather.add_argument('--run-directory', metavar='run_directory', help='The run directory', default='/var/lib/MinKNOW/data')
     parser_gather.set_defaults(func=run_subtool)
+
+    # guppyplex
+    # This is a workflow that aggregates the previous gather and demultiplex steps into a single task.
+    # This is making an assumption that the results from MinKnow demultiplex are good-enough.
+    parser_guppyplex = subparsers.add_parser('guppyplex', help='Aggregate pre-demultiplexed reads from MinKNOW/Guppy')
+    parser_guppyplex.add_argument('--directory', metavar='directory', help='Basecalled and demultiplexed (guppy) results directory', required=True)
+    parser_guppyplex.add_argument('--max-length', type=int, metavar='max_length', help='remove reads greater than read length')
+    parser_guppyplex.add_argument('--min-length', type=int, metavar='min_length', help='remove reads less than read length')
+    parser_guppyplex.add_argument('--quality', type=float, metavar='quality', default=7, help='remove reads against this quality filter')
+    parser_guppyplex.add_argument('--sample', type=float, metavar='sample', default=1, help='sampling frequency for random sample of sequence to reduce excess')
+    parser_guppyplex.add_argument('--prefix', help='Prefix for guppyplex files')
+    parser_guppyplex.add_argument('--run-directory', metavar='run_directory', help='The run directory', default='/var/lib/MinKNOW/data')
+    parser_guppyplex.set_defaults(func=run_subtool)
 
     # filter
     parser_filter = subparsers.add_parser('filter', help='Filter FASTQ files by length')


### PR DESCRIPTION
Dear Nick, PR here is aiming to provide some basic support for running the ARTIC workflow on sequence data that has already been demultiplexed by Guppy - following feedback from users in China there is a case for removing the requirement for the sequencing summary file for medaka workflow. To make this workflow minimally instrusive to existing code I have created a target called `guppyplex` in the pipeline.py - this aims to provide equivalent functionality to both the `gather` and `demultiplex` steps. I also have a snakefile for the automation of the workflow - would you like that committed here too - would welcome your thoughts here - very pleased to discuss further offline - Cheers - S 