### PR TITLE
Streamline nanopolish indexing

### DIFF
--- a/artic/demultiplex.py
+++ b/artic/demultiplex.py
@@ -27,6 +27,18 @@ def run(parser, args):
 		if newfn.endswith('.gz'):
 			os.system("gunzip -f %s" % (newfn,))
 
+		# build nanopolish index files for the demultiplexed reads if a readdb file exists for the input file
+		master_readdb_fn = "%s.index.readdb" % (args.fasta)
+		if os.path.exists(master_readdb_fn):
+			# first we build the .fai files intentionally WITHOUT the fast5 directory argument
+			# this will print an error that we ignore
+			cmd = ("nanopolish index %s 2>/dev/null" % newfn)
+			print(cmd, file=sys.stderr)
+			os.system(cmd)
+
+			new_readdb = "%s.index.readdb" % (newfn)
+			os.symlink(master_readdb_fn, new_readdb)
+
 	if not args.no_remove_directory:
 		os.rmdir(tmpdir)
 

--- a/artic/pipeline.py
+++ b/artic/pipeline.py
@@ -91,6 +91,8 @@ def main():
     parser_gather.add_argument('--min-length', type=int, metavar='min_length', help='remove reads less than read length')
     parser_gather.add_argument('--prefix', help='Prefix for gathered files')
     parser_gather.add_argument('--run-directory', metavar='run_directory', help='The run directory', default='/var/lib/MinKNOW/data')
+    parser_gather.add_argument('--fast5-directory', metavar='fast5_directory', help='The directory with fast5 files')
+    parser_gather.add_argument('--no-fast5s', action='store_true', help='Do not use fast5s and nanopolish', default=0)
     parser_gather.set_defaults(func=run_subtool)
 
     # filter


### PR DESCRIPTION
`artic gather` now builds nanopolish index files for the full read set, using the summary files it detects
`artic demultiplex` will build an index for barcoded fastqs, using the master .readdb file to avoid lengthy re-indexing

This improves the pipeline by reducing some steps (`nanopolish index` does not need to be run separately) and removes the need to pass `nanopolish-reads-file` to `artic minion`.