### PR TITLE
fixing type error

### DIFF
--- a/artic/vcftagprimersites.py
+++ b/artic/vcftagprimersites.py
@@ -40,12 +40,8 @@ def merge_sites(canonical, alt):
     dict
         A dictionary of the merged site, where the dict represents a bed file row
     """
-    # set up a new merged site to return
-    mergedSite = {}
-    mergedSite['Primer_ID'] = canonical['Primer_ID']
-    mergedSite['start'] = canonical['start']
-    mergedSite['end'] = canonical['end']
-    mergedSite['PoolName'] = canonical['PoolName']
+    # base the merged site on the canonical
+    mergedSite = canonical
 
     # check the both the canonical and alt are the same direction
     if canonical['direction'] != alt['direction']:

--- a/artic/vcftagprimersites.py
+++ b/artic/vcftagprimersites.py
@@ -45,6 +45,7 @@ def merge_sites(canonical, alt):
     mergedSite['Primer_ID'] = canonical['Primer_ID']
     mergedSite['start'] = canonical['start']
     mergedSite['end'] = canonical['end']
+    mergedSite['PoolName'] = canonical['PoolName']
 
     # check the both the canonical and alt are the same direction
     if canonical['direction'] != alt['direction']:
@@ -134,7 +135,7 @@ def read_bed_file(fn):
         bedFile[primerID] = mergedSite
 
     # return the bedFile as a list
-    return list(bedFile.values())
+    return [value for value in bedFile.values()]
 
 
 def overlaps(coords, pos):

--- a/artic/vcftagprimersites_test.py
+++ b/artic/vcftagprimersites_test.py
@@ -11,16 +11,21 @@ TEST_DIR = os.path.dirname(os.path.abspath(__file__))
 def test_read_bed_file():
 
     # process the nCoV-2019 V3 primer scheme
-    bedfile = vcftagprimersites.read_bed_file(
+    primerScheme = vcftagprimersites.read_bed_file(
         TEST_DIR + "/../test-data/primer-schemes/nCoV-2019/V3/nCoV-2019.scheme.bed")
 
     # check the the alts have been collapsed into a canonical primer site
-    assert len(bedfile) == 196, "alts were not collapsed"
+    assert len(primerScheme) == 196, "alts were not collapsed"
+
+    # check access to primer scheme fields
+    for row in primerScheme:
+        assert 'Primer_ID' in row, "failed to parse primer scheme for Primer_ID"
+        assert 'PoolName' in row, "failed to parse primer scheme for PoolName"
 
     # process the nCoV-2019 V2 primer scheme
     # this scheme has a single alt that has replaced the original primer so no alts should be collapsed
-    bedfile2 = vcftagprimersites.read_bed_file(
+    primerScheme2 = vcftagprimersites.read_bed_file(
         TEST_DIR + "/../test-data/primer-schemes/nCoV-2019/V2/nCoV-2019.bed")
-    assert len(bedfile2) == 196, "no alts should have been collapsed"
+    assert len(primerScheme2) == 196, "no alts should have been collapsed"
 
     # TODO: this is a starting point for the unit tests - more to come...


### PR DESCRIPTION
sorry - in haste I got the return type wrong.

This PR fixes that, updates the unit test and also fixes an error where poolname isn't copied across during merging of alts.