### PR TITLE
fixing vcf parse warning - no pool in header info

### DIFF
--- a/artic/vcf_merge.py
+++ b/artic/vcf_merge.py
@@ -23,6 +23,7 @@ def vcf_merge(args):
          first_vcf = file_name
 
    vcf_reader = vcf.Reader(filename=first_vcf)
+   vcf_reader.infos["Pool"] = vcf.parser._Format("Pool", 1, "String", "The pool name")
    vcf_writer = vcf.Writer(open(args.prefix+'.merged.vcf', 'w'), vcf_reader)
    vcf_writer_primers = vcf.Writer(open(args.prefix+'.primers.vcf', 'w'), vcf_reader)
 


### PR DESCRIPTION
this fix adds `pool` to an info tag in the vcf header during vcf-merge, removing the following warning during `artic minion`:

```
[W::vcf_parse] INFO 'Pool' is not defined in the header, assuming Type=String
```