### PR TITLE
update of env.yml for medaka v1.0.3 and dependencies

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,20 +5,21 @@ channels:
   - defaults
 dependencies:
   - artic-porechop==0.3.2pre
-  - bcftools=1.9
+  - bcftools=1.10.2
   - biopython=1.76
   - bwa=0.7.17
   - clint=0.5.1
+  - htslib=1.10.2
   - longshot=0.4.1
-  - medaka=0.12.1
+  - medaka=1.0.3
   - minimap2=2.17
   - muscle=3.8
   - nanopolish=0.13.2
   - nomkl
   - pandas=0.23.0
   - pip
-  - pysam=0.15.3
+  - pysam=0.16.0.1
   - pytest
   - python=3.6
   - pyvcf=0.6.8
-  - samtools=1.9
+  - samtools=1.10


### PR DESCRIPTION
Hi Will and Nick - update of MinKNOW and the underlying guppy version brings new error models - now would be a good time to update the included version of Medaka. Medaka now requires HTSLIB 1.10 - I have therefore amended the versions of samtools, bcftools and pysam (and included an explicit version of htslib). I have tested on a couple of systems - thanks for the consideration