### PR TITLE
Update medaka commands, ready for https://github.com/artic-network/fieldbioinformatics/pull/55

### DIFF
--- a/artic/minion.py
+++ b/artic/minion.py
@@ -88,7 +88,7 @@ def run(parser, args):
             if os.path.exists("%s.%s.hdf" % (args.sample, p)):
                 os.remove("%s.%s.hdf" % (args.sample, p))
 
-            cmds.append("medaka consensus --chunk_len 800 --chunk_ovlp 400 %s.primertrimmed.%s.sorted.bam %s.%s.hdf" % (args.sample, p, args.sample, p))
+            cmds.append("medaka consensus --model %s --threads %s --chunk_len 800 --chunk_ovlp 400 %s.primertrimmed.%s.sorted.bam %s.%s.hdf" % (args.medaka_model, args.threads, args.sample, p, args.sample, p))
             if args.no_indels:
                 cmds.append("medaka snp %s %s.%s.hdf %s.%s.vcf" % (ref, args.sample, p, args.sample, p))
             else:

--- a/artic/pipeline.py
+++ b/artic/pipeline.py
@@ -97,6 +97,8 @@ def init_pipeline_parser():
         'sample', metavar='sample', help='The name of the sample.')
     parser_minion.add_argument('--medaka', dest='medaka', action='store_true',
                                help='Use medaka instead of nanopolish for variants')
+    parser_minion.add_argument('--medaka-model', metavar='medaka_model',
+                                default='r941_min_high_g351', help='The model to use for medaka')
     parser_minion.add_argument('--minimap2', dest='minimap2', default=True,
                                action='store_true', help='Use minimap2 (default)')
     parser_minion.add_argument(

--- a/artic/pipeline.py
+++ b/artic/pipeline.py
@@ -92,21 +92,21 @@ def init_pipeline_parser():
     # minion
     parser_minion = subparsers.add_parser('minion', help='Run the alignment/variant-call/consensus pipeline')
     parser_minion.add_argument(
-        'scheme', metavar='scheme', help='The name of the scheme.')
+        'scheme', metavar='scheme', help='The name of the scheme')
     parser_minion.add_argument(
-        'sample', metavar='sample', help='The name of the sample.')
+        'sample', metavar='sample', help='The name of the sample')
     parser_minion.add_argument('--medaka', dest='medaka', action='store_true',
                                help='Use medaka instead of nanopolish for variants')
     parser_minion.add_argument('--medaka-model', metavar='medaka_model',
-                                default='r941_min_high_g351', help='The model to use for medaka')
+                                default='r941_min_high_g351', help='The model to use for medaka (default: %(default)s)')
     parser_minion.add_argument('--minimap2', dest='minimap2', default=True,
                                action='store_true', help='Use minimap2 (default)')
     parser_minion.add_argument(
         '--bwa', dest='bwa', action='store_true', help='Use bwa instead of minimap2')
     parser_minion.add_argument('--normalise', dest='normalise', type=int,
-                               default=100, help='Normalise down to moderate coverage to save runtime.')
+                               default=100, help='Normalise down to moderate coverage to save runtime (default: %(default)d, deactivate with `--normalise 0`)')
     parser_minion.add_argument(
-        '--threads', type=int, default=8, help='Number of threads')
+        '--threads', type=int, default=8, help='Number of threads (default: %(default)d)')
     parser_minion.add_argument('--scheme-directory', metavar='scheme_directory',
                                default='/artic/schemes', help='Default scheme directory')
     parser_minion.add_argument('--max-haplotypes', type=int, default=1000000,


### PR DESCRIPTION
This PR adds `--medaka-model` to the minion command, and updates the call to `medaka consensus` to set additional flags:

* `--model`
* `--threads`

The default model used is `r941_min_high_g351`

Whilst I was there - I also added specific print statements to produce the defaults in the minion command help. This fixes https://github.com/artic-network/fieldbioinformatics/issues/27

Once this is merged, we can test and merge https://github.com/artic-network/fieldbioinformatics/pull/55