### PR TITLE
Enforce amplicon coverage

### DIFF
--- a/artic/minion.py
+++ b/artic/minion.py
@@ -84,7 +84,8 @@ def run(parser, args):
             
             # if not using longshot, annotate VCF with read depth info etc. so we can filter it
             if args.no_longshot:
-                cmds.append("medaka tools annotate --pad 25 --RG %s %s.%s.vcf %s %s.trimmed.rg.sorted.bam %s.%s.vcf" % (p, args.sample, p, ref, args.sample, args.sample, p))
+                cmds.append("medaka tools annotate --pad 25 --RG %s %s.%s.vcf %s %s.trimmed.rg.sorted.bam tmp.medaka-annotate.vcf" % (p, args.sample, p, ref, args.sample))
+                cmds.append("mv tmp.medaka-annotate.vcf %s.%s.vcf" % (args.sample, p))
 
     else:
         if not args.skip_nanopolish:

--- a/artic/minion.py
+++ b/artic/minion.py
@@ -55,10 +55,10 @@ def run(parser, args):
 
     # 3) index the ref & align with minimap or bwa
     if not args.bwa:
-        cmds.append("minimap2 -a -x map-ont -t %s %s %s | samtools view -q 30 -bS -F 4 - | samtools sort -o %s.sorted.bam -" % (args.threads, ref, read_file, args.sample))
+        cmds.append("minimap2 -a -x map-ont -t %s %s %s | samtools view -bS -F 4 - | samtools sort -o %s.sorted.bam -" % (args.threads, ref, read_file, args.sample))
     else:
         cmds.append("bwa index %s" % (ref,))
-        cmds.append("bwa mem -t %s -x ont2d %s %s | samtools view -q 30 -bS -F 4 - | samtools sort -o %s.sorted.bam -" % (args.threads, ref, read_file, args.sample))
+        cmds.append("bwa mem -t %s -x ont2d %s %s | samtools view -bS -F 4 - | samtools sort -o %s.sorted.bam -" % (args.threads, ref, read_file, args.sample))
     cmds.append("samtools index %s.sorted.bam" % (args.sample,))
 
     # 4) trim the alignments to the primer start sites and normalise the coverage to save time
@@ -115,7 +115,7 @@ def run(parser, args):
     vcf_file = "%s.pass.vcf" % (args.sample)
 
     # filter the variants to produce PASS and FAIL lists, then index them
-    cmds.append("artic_vcf_filter --%s %s.merged.vcf %s.pass.vcf %s.fail.vcf" % (method, args.sample, args.sample, args.sample))
+    cmds.append("artic_vcf_filter --%s %s %s.merged.vcf %s.pass.vcf %s.fail.vcf" % (method, bed, args.sample, args.sample, args.sample))
     cmds.append("bgzip -f %s" % (vcf_file))
     cmds.append("tabix -p vcf %s.gz" % (vcf_file))
 

--- a/artic/minion.py
+++ b/artic/minion.py
@@ -124,7 +124,7 @@ def run(parser, args):
         normalise_string = '--normalise %d' % (args.normalise)
     else:
         normalise_string = ''
-    cmds.append("align_trim --start %s %s --report %s.alignreport.txt < %s.sorted.bam 2> %s.alignreport.er | samtools sort -T %s - -o %s.trimmed.rg.sorted.bam" % (normalise_string, bed, args.sample, args.sample, args.sample, args.sample, args.sample))
+    cmds.append("align_trim %s %s --start --remove-incorrect-pairs --report %s.alignreport.txt < %s.sorted.bam 2> %s.alignreport.er | samtools sort -T %s - -o %s.trimmed.rg.sorted.bam" % (normalise_string, bed, args.sample, args.sample, args.sample, args.sample, args.sample))
     cmds.append("align_trim %s %s --remove-incorrect-pairs --report %s.alignreport.txt < %s.sorted.bam 2> %s.alignreport.er | samtools sort -T %s - -o %s.primertrimmed.rg.sorted.bam" % (normalise_string, bed, args.sample, args.sample, args.sample, args.sample, args.sample))
     cmds.append("samtools index %s.trimmed.rg.sorted.bam" % (args.sample))
     cmds.append("samtools index %s.primertrimmed.rg.sorted.bam" % (args.sample))

--- a/artic/minion.py
+++ b/artic/minion.py
@@ -8,49 +8,107 @@ import time
 from .vcftagprimersites import read_bed_file
 
 def get_nanopolish_header(ref):
+    """Checks the reference sequence for a single fasta entry.
+
+    Parameters
+    ----------
+    ref : str
+        The fasta file containing the reference sequence
+
+    Returns
+    -------
+    str
+        A formatted header string for nanopolish
+    """
     recs = list(SeqIO.parse(open(ref), "fasta"))
     if len (recs) != 1:
         print("FASTA has more than one sequence", file=sys.stderr)
         raise SystemExit(1)
-
     return  "%s:%d-%d" % (recs[0].id, 1, len(recs[0])+1)
 
+def get_scheme(scheme_name, scheme_directory, scheme_version="1"):
+    """Get and check the ARTIC primer scheme.
+
+    When determining a version, the original behaviour (parsing the scheme_name and
+    separating on /V ) is used over a specified scheme_version. If neither are
+    provided, the version defaults to 1.
+
+    If 0 is provided as version, the latest scheme will be downloaded.
+ 
+    Parameters
+    ----------
+    scheme_name : str
+        The primer scheme name
+    scheme_directory : str
+        The directory containing the primer scheme and reference sequence
+    scheme_version : str
+        The primer scheme version (optional)
+
+    Returns
+    -------
+    str
+        The location of the checked primer scheme
+    str
+        The location of the checked reference sequence
+    str
+        The version being used
+    """
+    # try getting the version from the scheme name (old behaviour)
+    if scheme_name.find('/V') != -1:
+        scheme_name, scheme_version = scheme_name.split('/V')
+    
+    # create the filenames and check they exist
+    bed = "%s/%s/V%s/%s.scheme.bed" % (scheme_directory, scheme_name, scheme_version, scheme_name)
+    ref = "%s/%s/V%s/%s.reference.fasta" % (scheme_directory, scheme_name, scheme_version, scheme_name)
+    if os.path.exists(bed) and os.path.exists(ref):
+        return bed, ref, scheme_version
+    
+    # if they don't exist, try downloading them to the current directory
+    print(colored.yellow("could not find primer scheme and reference sequence, attempting to download"), file=sys.stderr)
+    getScheme = "artic-tools get_scheme %s --schemeVersion %s" % (scheme_name, scheme_version)
+    print(colored.green("Running: "), getScheme, file=sys.stderr)
+    if (os.system(getScheme) != 0):
+        print(colored.red("scheme download failed"), file=sys.stderr)
+        raise SystemExit(1)
+    bed = "%s.v%s.scheme.bed" % (scheme_name, scheme_version)
+    ref = "%s.v%s.reference.fasta" % (scheme_name, scheme_version)
+    if os.path.exists(bed) and os.path.exists(ref):
+        return bed, ref, scheme_version
+    print(colored.red('could not find/download primer scheme: ') + scheme_name)
+    raise SystemExit(1)
+
 def run(parser, args):
-    log = "%s.minion.log.txt" % (args.sample)
-    logfh = open(log, 'w')
 
-    if args.scheme.find('/') != -1:
-        scheme_name, scheme_version = args.scheme.split('/')
-    else:
-        scheme_name = args.scheme
-        scheme_version = "V1"
+    # 1) check the parameters and set up the filenames
+    ## find the primer scheme, reference sequence and confirm scheme version
+    bed, ref, scheme_version = get_scheme(args.scheme, args.scheme_directory, args.scheme_version)
 
-    ref = "%s/%s/%s/%s.reference.fasta" % (args.scheme_directory, scheme_name, scheme_version, scheme_name)
-    bed = "%s/%s/%s/%s.scheme.bed" % (args.scheme_directory, scheme_name, scheme_version, scheme_name)
+    ## if in strict mode, validate the primer scheme
+    if args.strict:
+        checkScheme = "artic-tools validate_scheme %s --schemeVersion %s" % (bed, scheme_version)
+        print(colored.green("Running: "), checkScheme, file=sys.stderr)
+        if (os.system(checkScheme) != 0):
+            print(colored.red("primer scheme failed strict checking"), file=sys.stderr)
+            raise SystemExit(1)
 
+    ## set up the read file
     if args.read_file:
         read_file = args.read_file
     else:
         read_file = "%s.fasta" % (args.sample)
 
-    if not os.path.exists(ref):
-        print(colored.red('Scheme reference file not found: ') + ref)
-        raise SystemExit(1)
-    if not os.path.exists(bed):
-        print(colored.red('Scheme BED file not found: ') + bed)
-        raise SystemExit(1)
-
+    ## collect the primer pools
     pools = set([row['PoolName'] for row in read_bed_file(bed)])
 
+    ## create a holder to keep the pipeline commands in
     cmds = []
 
+    # 2) if using nanopolish, set up the reference header and run the nanopolish indexing
     nanopolish_header = get_nanopolish_header(ref)
-
     if not args.medaka and not args.skip_nanopolish:
         if not args.fast5_directory or not args.sequencing_summary:
               print(colored.red('Must specify FAST5 directory and sequencing summary for nanopolish mode.'))
               raise SystemExit(1)
-        
         cmds.append("nanopolish index -s %s -d %s %s" % (args.sequencing_summary, args.fast5_directory, args.read_file,))
 
     # 3) index the ref & align with minimap or bwa
@@ -82,7 +140,7 @@ def run(parser, args):
             else:
                 cmds.append("medaka variant %s %s.%s.hdf %s.%s.vcf" % (ref, args.sample, p, args.sample, p))
             
-            # if not using longshot, annotate VCF with read depth info etc. so we can filter it
+            ## if not using longshot, annotate VCF with read depth info etc. so we can filter it
             if args.no_longshot:
                 cmds.append("medaka tools annotate --pad 25 --RG %s %s.%s.vcf %s %s.trimmed.rg.sorted.bam tmp.medaka-annotate.vcf" % (p, args.sample, p, ref, args.sample))
                 cmds.append("mv tmp.medaka-annotate.vcf %s.%s.vcf" % (args.sample, p))
@@ -97,45 +155,53 @@ def run(parser, args):
             for p in pools:
                 cmds.append("nanopolish variants --min-flanking-sequence 10 -x %s --progress -t %s --reads %s -o %s.%s.vcf -b %s.trimmed.rg.sorted.bam -g %s -w \"%s\" --ploidy 1 -m 0.15 --read-group %s %s" % (args.max_haplotypes, args.threads, indexed_nanopolish_file, args.sample, p, args.sample, ref, nanopolish_header, p, nanopolish_extra_args))
 
-    # merge the called variants for each read group
+    # 7) merge the called variants for each read group
     merge_vcf_cmd = "artic_vcf_merge %s %s" % (args.sample, bed)
     for p in pools:
         merge_vcf_cmd += " %s:%s.%s.vcf" % (p, args.sample, p)
     cmds.append(merge_vcf_cmd)
 
-    # if doing the medaka workflow and longshot required, do it on the merged VCF
+    # 8) check and filter the VCFs
+    ## if using strict, run the vcf checker to remove vars present only once in overlap regions (this replaces the original merged vcf from the previous step)
+    if args.strict:
+        cmds.append("artic-tools check_vcf --dropPrimerVars --dropOverlapFails --vcfOut %s.merged.filtered.vcf --schemeVersion %s %s %s.merged.vcf 2> %s.vcfreport.txt" % (args.sample, scheme_version, bed, args.sample, args.sample))
+        cmds.append("mv %s.merged.filtered.vcf %s.merged.vcf" % (args.sample, args.sample))
+
+    ## if doing the medaka workflow and longshot required, do it on the merged VCF
     if args.medaka and not args.no_longshot:
         cmds.append("bgzip -f %s.merged.vcf" % (args.sample))
         cmds.append("tabix -p vcf %s.merged.vcf.gz" % (args.sample))
         cmds.append("longshot -P 0 -F -A --no_haps --bam %s.primertrimmed.rg.sorted.bam --ref %s --out %s.merged.vcf --potential_variants %s.merged.vcf.gz" % (args.sample, ref, args.sample, args.sample))
 
-    # set up some name holder vars for ease
+    ## set up some name holder vars for ease
     if args.medaka:
         method = 'medaka'
     else:
         method = 'nanopolish'
     vcf_file = "%s.pass.vcf" % (args.sample)
 
-    # filter the variants to produce PASS and FAIL lists, then index them
+    ## filter the variants to produce PASS and FAIL lists, then index them
     cmds.append("artic_vcf_filter --%s %s.merged.vcf %s.pass.vcf %s.fail.vcf" % (method, args.sample, args.sample, args.sample))
     cmds.append("bgzip -f %s" % (vcf_file))
     cmds.append("tabix -p vcf %s.gz" % (vcf_file))
 
-    # get the depth of coverage for each readgroup and create a coverage mask and plots
+    # 9) get the depth of coverage for each readgroup, create a coverage mask and plots, and add failed variants to the coverage mask (artic_mask must be run before bcftools consensus)
     cmds.append("artic_make_depth_mask --store-rg-depths %s %s.primertrimmed.rg.sorted.bam %s.coverage_mask.txt" % (ref, args.sample, args.sample))
     cmds.append("artic_plot_amplicon_depth --primerScheme %s --sampleID %s --outFilePrefix %s %s*.depths" % (bed, args.sample, args.sample, args.sample))
-
-    # add the failed variants to the coverage mask
-    # artic_mask must be run before bcftools consensus
     cmds.append("artic_mask %s %s.coverage_mask.txt %s.fail.vcf %s.preconsensus.fasta" % (ref, args.sample, args.sample, args.sample))
+
+    # 10) generate the consensus sequence
     cmds.append("bcftools consensus -f %s.preconsensus.fasta %s.gz -m %s.coverage_mask.txt -o %s.consensus.fasta" % (args.sample, vcf_file, args.sample, args.sample))
 
-    # apply header to the consensus sequence and run alignment
+    # 11) apply the header to the consensus sequence and run alignment against the reference sequence
     fasta_header = "%s/ARTIC/%s" % (args.sample, method)
     cmds.append("artic_fasta_header %s.consensus.fasta \"%s\"" % (args.sample, fasta_header))
     cmds.append("cat %s.consensus.fasta %s > %s.muscle.in.fasta" % (args.sample, ref, args.sample))
     cmds.append("muscle -in %s.muscle.in.fasta -out %s.muscle.out.fasta" % (args.sample, args.sample))
 
+    # 12) setup the log file and run the pipeline commands
+    log = "%s.minion.log.txt" % (args.sample)
+    logfh = open(log, 'w')
     for cmd in cmds:
         print(colored.green("Running: ") + cmd, file=sys.stderr)
         if not args.dry_run:
@@ -146,10 +212,10 @@ def run(parser, args):
                 raise SystemExit(20)
             timerStop = time.perf_counter()
 
-            # print the executed command and the runtime to the log file
+            ## print the executed command and the runtime to the log file
             print("{}\t{}" .format(cmd, timerStop-timerStart), file=logfh)
         
-        # if it's a dry run, print just the command
+        ## if it's a dry run, print just the command
         else:
             print(cmd, file=logfh)
     logfh.close()

--- a/artic/minion_validator.py
+++ b/artic/minion_validator.py
@@ -37,7 +37,7 @@ dataDir = TEST_DIR + "/../test-data/"
 
 # testData is a lookup of sampleIDs to download urls
 testData = {
-    #"MT007544": "https://raw.githubusercontent.com/artic-network/fieldbioinformatics/master/test-data/MT007544/MT007544.fastq",
+    "MT007544": "https://raw.githubusercontent.com/artic-network/fieldbioinformatics/master/test-data/MT007544/MT007544.fastq",
     "CVR1": "https://artic.s3.climb.ac.uk/validation-sets/CVR1.tgz",
     "NRW01": "http://artic.s3.climb.ac.uk/validation-teams/NRW01.tgz",
     "SP1": "http://artic.s3.climb.ac.uk/validation-teams/SP1.tgz"
@@ -52,7 +52,7 @@ refConsensuses = {
 
 # refMedakaConsensuses is a nested dict of sample IDs and their expected consensus sequences from the medaka workflow
 refMedakaConsensuses = {
-    #"MT007544": dataDir + "consensus-sequences/MT007544.consensus.medaka.fasta",
+    "MT007544": dataDir + "consensus-sequences/MT007544.consensus.medaka.fasta",
     "CVR1": dataDir + "consensus-sequences/CVR1.consensus.medaka.fasta",
     "NRW01": dataDir + "consensus-sequences/NRW01.consensus.medaka.fasta",
     "SP1": dataDir + "consensus-sequences/SP1.consensus.medaka.fasta"
@@ -93,16 +93,15 @@ nanopolishTestVariants = {
 
 # medakaTestVariants is a nested dict of sample IDs and their expected variants when using the medaka workflow
 medakaTestVariants = {
-    #"MT007544":
-    #    {
-    #        # pos: (ref, alt, type, count)
-    #        29749: ["ACGATCGAGTG", 'A', "del", 1]
-    #    },
+    "MT007544":
+        {
+            # pos: (ref, alt, type, count)
+            29749: ["ACGATCGAGTG", 'A', "del", 1]
+        },
     "CVR1":
         {
             241: ['C', 'T', "snp", 1],
             3037: ['C', 'T', "snp", 1],
-            12733: ['C', 'T', "snp", 1],
             12733: ['C', 'T', "snp", 2],
             14408: ['C', 'T', "snp", 1],
             23403: ['A', 'G', "snp", 1],

--- a/artic/minion_validator.py
+++ b/artic/minion_validator.py
@@ -37,7 +37,7 @@ dataDir = TEST_DIR + "/../test-data/"
 
 # testData is a lookup of sampleIDs to download urls
 testData = {
-    "MT007544": "https://raw.githubusercontent.com/artic-network/fieldbioinformatics/master/test-data/MT007544/MT007544.fastq",
+    #"MT007544": "https://raw.githubusercontent.com/artic-network/fieldbioinformatics/master/test-data/MT007544/MT007544.fastq",
     "CVR1": "https://artic.s3.climb.ac.uk/validation-sets/CVR1.tgz",
     "NRW01": "http://artic.s3.climb.ac.uk/validation-teams/NRW01.tgz",
     "SP1": "http://artic.s3.climb.ac.uk/validation-teams/SP1.tgz"
@@ -52,7 +52,7 @@ refConsensuses = {
 
 # refMedakaConsensuses is a nested dict of sample IDs and their expected consensus sequences from the medaka workflow
 refMedakaConsensuses = {
-    "MT007544": dataDir + "consensus-sequences/MT007544.consensus.medaka.fasta",
+    #"MT007544": dataDir + "consensus-sequences/MT007544.consensus.medaka.fasta",
     "CVR1": dataDir + "consensus-sequences/CVR1.consensus.medaka.fasta",
     "NRW01": dataDir + "consensus-sequences/NRW01.consensus.medaka.fasta",
     "SP1": dataDir + "consensus-sequences/SP1.consensus.medaka.fasta"
@@ -93,11 +93,11 @@ nanopolishTestVariants = {
 
 # medakaTestVariants is a nested dict of sample IDs and their expected variants when using the medaka workflow
 medakaTestVariants = {
-    "MT007544":
-        {
-            # pos: (ref, alt, type, count)
-            29749: ["ACGATCGAGTG", 'A', "del", 1]
-        },
+    #"MT007544":
+    #    {
+    #        # pos: (ref, alt, type, count)
+    #        29749: ["ACGATCGAGTG", 'A', "del", 1]
+    #    },
     "CVR1":
         {
             241: ['C', 'T', "snp", 1],

--- a/artic/pipeline.py
+++ b/artic/pipeline.py
@@ -110,6 +110,8 @@ def init_pipeline_parser():
         '--threads', type=int, default=8, help='Number of threads (default: %(default)d)')
     parser_minion.add_argument('--scheme-directory', metavar='scheme_directory',
                                default='/artic/schemes', help='Default scheme directory')
+    parser_minion.add_argument('--scheme-version', metavar='scheme_version',
+                                default=1, help='Primer scheme version (default: %(default)d)')
     parser_minion.add_argument('--max-haplotypes', type=int, default=1000000,
                                metavar='max_haplotypes', help='max-haplotypes value for nanopolish')
     parser_minion.add_argument('--read-file', metavar='read_file',
@@ -120,6 +122,7 @@ def init_pipeline_parser():
     parser_minion.add_argument('--skip-nanopolish', action='store_true')
     parser_minion.add_argument('--no-indels', action='store_true')
     parser_minion.add_argument('--dry-run', action='store_true')
+    parser_minion.add_argument('--strict', action='store_true', help='Run with strict filtering of variants against primer scheme')
     parser_minion.set_defaults(func=run_subtool)
 
     # gather

--- a/artic/pipeline.py
+++ b/artic/pipeline.py
@@ -99,6 +99,7 @@ def init_pipeline_parser():
                                help='Use medaka instead of nanopolish for variants')
     parser_minion.add_argument('--medaka-model', metavar='medaka_model',
                                 default='r941_min_high_g351', help='The model to use for medaka (default: %(default)s)')
+    parser_minion.add_argument('--no-longshot', dest='no_longshot', action='store_true', help='Do not use Longshot for variant filtering after medaka')
     parser_minion.add_argument('--minimap2', dest='minimap2', default=True,
                                action='store_true', help='Use minimap2 (default)')
     parser_minion.add_argument(

--- a/artic/vcf_filter.py
+++ b/artic/vcf_filter.py
@@ -54,8 +54,6 @@ class MedakaFilter:
         depth = v.INFO['DP']
         if depth < 20:
             return False
-        if v.QUAL < 20:
-            return False
 
         if self.no_frameshifts and not in_frame(v):
             return False
@@ -85,19 +83,12 @@ def go(args):
     
     for v in variants:
 
-        # if using medaka, we need to do a quick pre-filter to remove rubbish
+        # if using medaka, we need to do a quick pre-filter to remove rubbish that we don't want adding to the mask
         if args.medaka:
-            dp = v.INFO['DP']
-            ar = sum(v.INFO['AR'])
-
-            # skip where only one read is in support
-            if dp <= 1:
+            if v.INFO['DP'] <= 1:
                 continue
-
-            # skip vars where there are too many ambiguous reads in support
-            if ar != 0:
-                if (ar/dp > 0.7):
-                    continue
+            if v.QUAL < 20:
+                continue
 
         # now apply the filter to send variants to PASS or FAIL file
         if filter.check_filter(v):

--- a/environment.yml
+++ b/environment.yml
@@ -10,6 +10,7 @@ dependencies:
   - bwa=0.7.17
   - clint=0.5.1
   - htslib=1.10.2
+  - longshot=0.4.1
   - medaka=1.0.3
   - minimap2=2.17
   - muscle=3.8

--- a/environment.yml
+++ b/environment.yml
@@ -5,6 +5,7 @@ channels:
   - defaults
 dependencies:
   - artic-porechop==0.3.2pre
+  - artic-tools==0.2.2
   - bcftools=1.10.2
   - biopython=1.76
   - bwa=0.7.17

--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,6 @@ dependencies:
   - bwa=0.7.17
   - clint=0.5.1
   - htslib=1.10.2
-  - longshot=0.4.1
   - medaka=1.0.3
   - minimap2=2.17
   - muscle=3.8


### PR DESCRIPTION
This PR updates `align_trim` so that alignment segments not spanning an entire amplicon are dropped.

This PR should be considered after https://github.com/artic-network/fieldbioinformatics/pull/60

Although Travis tests pass, the test dataset NRW01 (not run by Travis) will currently fail due to the consensus sequence produced by this PR containing extra terminal Ns. This is due to low coverage in the final amplicon, which causes a larger depth mask than previously had for this sample. We can either update the consensus sequence for NRW01 tests or play with the minimum coverage in `artic_make_depth_mask`

Old coverage mask for NRW01:
```
MN908947.3	1	54
MN908947.3	29810	29903
```

New coverage mask for NRW01:
```
MN908947.3	1	54
MN908947.3	29666	29903
```