### PR TITLE
bugfix: bcftools overlapping variants issue

### DIFF
--- a/artic/minion.py
+++ b/artic/minion.py
@@ -264,6 +264,8 @@ def run(parser, args):
     cmds.append("artic_mask %s %s.coverage_mask.txt %s.fail.vcf %s.preconsensus.fasta" % (ref, args.sample, args.sample, args.sample))
 
     # 10) generate the consensus sequence
+    cmds.append("bcftools norm --check-ref x --fasta-ref %s.preconsensus.fasta -O z -o %s.gz %s" %(args.sample, vcf_file, vcf_file))
+    cmds.append("tabix -p vcf %s.gz" % (vcf_file))
     cmds.append("bcftools consensus -f %s.preconsensus.fasta %s.gz -m %s.coverage_mask.txt -o %s.consensus.fasta" % (args.sample, vcf_file, args.sample, args.sample))
 
     # 11) apply the header to the consensus sequence and run alignment against the reference sequence


### PR DESCRIPTION
* this is just a cherry-pick from the [1.3.0 PR ](https://github.com/artic-network/fieldbioinformatics/pull/70) 
* I believe this should fix the overlapping variants issue as detailed [here](https://github.com/artic-network/artic-ncov2019/issues/38) which has been a persistent issue for us
* The occurrence at which runs fail at the `bcftools consensus` step has been increasing over time

