### PR TITLE
feat: make flag -A in Longshot optional

### DIFF
--- a/artic/minion.py
+++ b/artic/minion.py
@@ -242,7 +242,10 @@ def run(parser, args):
     if args.medaka and not args.no_longshot:
         cmds.append("bgzip -f %s.merged.vcf" % (args.sample))
         cmds.append("tabix -f -p vcf %s.merged.vcf.gz" % (args.sample))
-        cmds.append("longshot -P 0 -F -A --no_haps --bam %s.primertrimmed.rg.sorted.bam --ref %s --out %s.merged.vcf --potential_variants %s.merged.vcf.gz" % (args.sample, ref, args.sample, args.sample))
+        if args.no_auto_max_cov:
+            cmds.append("longshot -P 0 -F --no_haps --bam %s.primertrimmed.rg.sorted.bam --ref %s --out %s.merged.vcf --potential_variants %s.merged.vcf.gz" % (args.sample, ref, args.sample, args.sample))
+        else:
+            cmds.append("longshot -P 0 -F -A --no_haps --bam %s.primertrimmed.rg.sorted.bam --ref %s --out %s.merged.vcf --potential_variants %s.merged.vcf.gz" % (args.sample, ref, args.sample, args.sample))
 
     ## set up some name holder vars for ease
     if args.medaka:

--- a/artic/pipeline.py
+++ b/artic/pipeline.py
@@ -99,6 +99,7 @@ def init_pipeline_parser():
                                help='Use medaka instead of nanopolish for variants')
     parser_minion.add_argument('--medaka-model', metavar='medaka_model', help='The model to use for medaka (required if using --medaka)')
     parser_minion.add_argument('--no-longshot', dest='no_longshot', action='store_true', help='Do not use Longshot for variant filtering after medaka')
+    parser_minion.add_argument('--no-auto_max_cov', dest='no_auto_max_cov', action='store_true', help='When running Longshot, do not use its --auto_max_cov flag')
     parser_minion.add_argument('--minimap2', dest='minimap2', default=True,
                                action='store_true', help='Use minimap2 (default)')
     parser_minion.add_argument(


### PR DESCRIPTION
This PR adds a new flag to `artic minion`, allowing the user to choose whether or not to use flag `-A` (`--auto_max_cov`) when running `longshot`.
By default, the flag `-A` is used, so that current behavior remains unchanged upon updating. When setting `--no-auto_max_cov`, the call to `longshot` is made without flag `-A`.

This change closes issue #91.