### PR TITLE
fix: Ignore bases outside the reference

### DIFF
--- a/artic/make_depth_mask.py
+++ b/artic/make_depth_mask.py
@@ -65,7 +65,7 @@ def collect_depths(bamfile, refName, minDepth, ignoreDeletions, warnRGcov):
     lowRGvec = []
 
     # generate the pileup
-    for pileupcolumn in bamFile.pileup(refName, max_depth=10000, truncate=False, min_base_quality=0):
+    for pileupcolumn in bamFile.pileup(refName, start=0, stop=bamFile.get_reference_length(refName), max_depth=10000, truncate=True, min_base_quality=0):
 
         # process the pileup column
         for pileupread in pileupcolumn.pileups:


### PR DESCRIPTION
This PR fixes a bug we bumped into, where reads that map partially beyond the end of the reference cause `artic minion` to crash.

The problem arises because the size of the vector `depths` in `make_depth_mask.py` is equal to the length of the reference. When calling `bamFile.pileup(...)`, however, `pileupcolumn.pos` might cause an `Index out of range` error if there is a read that goes beyond the end of the reference or before its start position.

Since these sections of the reads are irrelevant to calculate coverage, the solution implemented here is to set boundaries for the `bamFile.pileup(...)` function, so that it only considers bases within the reference.