### PR TITLE
fix: update longshot to avoid intermittent `thread 'main' panicked at 'assertion failed: p <= 0.0'` error

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,7 @@ dependencies:
   - bwa=0.7.17
   - clint=0.5.1
   - htslib=1.10.2
-  - longshot=0.4.1
+  - longshot>=0.4.3
   - medaka=1.0.3
   - minimap2=2.17
   - multiqc


### PR DESCRIPTION
To fix issue #109 (longshot crashing for certain files), I've updated `environment.yml` to use a newer version in which this error has been fixed (0.4.3 and above should do the trick, both conda and mamba pull 0.4.5 for me). 