### PR TITLE
Fix align_trim:find_primer

### DIFF
--- a/artic/align_trim.py
+++ b/artic/align_trim.py
@@ -36,10 +36,10 @@ def find_primer(bed, pos, direction):
 
     if direction == '+':
         closest = min([(abs(p['start'] - pos), p['start'] - pos, p)
-                       for p in bed if p['direction'] == direction], key=itemgetter(0))
+                       for p in bed if (p['direction'] == direction) and (p['start'] - pos <= 0)], key=itemgetter(0))
     else:
         closest = min([(abs(p['end'] - pos), p['end'] - pos, p)
-                       for p in bed if p['direction'] == direction], key=itemgetter(0))
+                       for p in bed if (p['direction'] == direction) and (p['end'] - pos >= 0)], key=itemgetter(0))
     return closest
 
 


### PR DESCRIPTION
This PR fixes find_primers to search in the appropriate direction for left or right primers. In particular, this fix helps when using the Rapid Barcoding Kit. More reads are assigned the correct primer pair and group number, leading to more reads being used in consensus sequence generation.

The function find_primer searches, in both 5' and 3' directions, for the nearest primer to a position on a given strand. This causes issues with using the Nanopore Rapid Barcoding Kit, which makes reads that begin in the middle of amplicons. These reads are assigned the wrong primer pairs and are filtered out. 

The correction is to add a condition to the list comprehension **and (p['start'] - pos <= 0)**. 

