### PR TITLE
1.5.6 PR (fixes #144)

### DIFF
--- a/artic/minion.py
+++ b/artic/minion.py
@@ -134,11 +134,19 @@ def run(parser, args):
         normalise_string = ""
 
     cmds.append(
-        f"align_trim {normalise_string} {bed} --primer-match-threshold {args.primer_match_threshold} --remove-incorrect-pairs --min-mapq {args.min_mapq} --report {args.sample}.alignreport.csv < {args.sample}.sorted.bam 2> {args.sample}.alignreport.er | samtools sort -T {args.sample} - -o {args.sample}.trimmed.rg.sorted.bam"
+        f"align_trim {normalise_string} {bed} --primer-match-threshold {args.primer_match_threshold} --remove-incorrect-pairs --min-mapq {args.min_mapq} --report {args.sample}.alignreport.csv < {args.sample}.sorted.bam > {args.sample}.trimmed.rg.bam"
     )
 
     cmds.append(
-        f"align_trim {normalise_string} {bed} --primer-match-threshold {args.primer_match_threshold} --min-mapq {args.min_mapq} --remove-incorrect-pairs --trim-primers --report {args.sample}.alignreport.csv --amp-depth-report {args.sample}.amplicon_depths.tsv < {args.sample}.sorted.bam 2> {args.sample}.alignreport.er | samtools sort -T {args.sample} - -o {args.sample}.primertrimmed.rg.sorted.bam"
+        f"samtools sort -T {args.sample} {args.sample}.trimmed.rg.bam -o {args.sample}.trimmed.rg.sorted.bam"
+    )
+
+    cmds.append(
+        f"align_trim {normalise_string} {bed} --primer-match-threshold {args.primer_match_threshold} --min-mapq {args.min_mapq} --remove-incorrect-pairs --trim-primers --report {args.sample}.alignreport.csv --amp-depth-report {args.sample}.amplicon_depths.tsv < {args.sample}.sorted.bam > {args.sample}.primertrimmed.rg.bam"
+    )
+
+    cmds.append(
+        f"samtools sort -T {args.sample} {args.sample}.primertrimmed.rg.bam -o {args.sample}.primertrimmed.rg.sorted.bam"
     )
 
     cmds.append(f"samtools index {args.sample}.trimmed.rg.sorted.bam")

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = artic
-version = 1.5.5
+version = 1.5.6
 author = Nick Loman
 author_email = n.j.loman@bham.ac.uk
 maintainer = Sam Wilkinson

--- a/tests/align_trim_unit_test.py
+++ b/tests/align_trim_unit_test.py
@@ -92,10 +92,6 @@ def test_trim():
 
     def testRunner(seg, expectedCIGAR):
 
-        global args
-
-        args = SimpleNamespace(verbose=False)
-
         # get the nearest primers to the alignment segment
         p1 = align_trim.find_primer(primerScheme, seg.reference_start, "+")
         p2 = align_trim.find_primer(primerScheme, seg.reference_end, "-")

--- a/tests/align_trim_unit_test.py
+++ b/tests/align_trim_unit_test.py
@@ -1,7 +1,7 @@
 # align_trim_unit_test.py contains unit tests for alignment trimming
 import os
 import pysam
-import pytest
+from types import SimpleNamespace
 
 from artic import align_trim
 from artic import utils
@@ -92,6 +92,10 @@ def test_trim():
 
     def testRunner(seg, expectedCIGAR):
 
+        global args
+
+        args = SimpleNamespace(verbose=False)
+
         # get the nearest primers to the alignment segment
         p1 = align_trim.find_primer(primerScheme, seg.reference_start, "+")
         p2 = align_trim.find_primer(primerScheme, seg.reference_end, "-")
@@ -114,7 +118,7 @@ def test_trim():
 
         # trim the forward primer
         try:
-            align_trim.trim(seg, p1_position, False, False)
+            align_trim.trim(seg, p1_position, False)
         except Exception as e:
             raise Exception(
                 "problem soft masking left primer in {} (error: {})".format(
@@ -132,7 +136,7 @@ def test_trim():
 
         # trim the reverse primer
         try:
-            align_trim.trim(seg, p2_position, True, False)
+            align_trim.trim(seg, p2_position, True)
         except Exception as e:
             raise Exception(
                 "problem soft masking right primer in {} (error: {})".format(

--- a/tests/align_trim_unit_test.py
+++ b/tests/align_trim_unit_test.py
@@ -1,7 +1,6 @@
 # align_trim_unit_test.py contains unit tests for alignment trimming
 import os
 import pysam
-from types import SimpleNamespace
 
 from artic import align_trim
 from artic import utils

--- a/tests/minion_validator.py
+++ b/tests/minion_validator.py
@@ -184,13 +184,9 @@ def genCommand(sampleID, workflow):
         "--scheme-directory",
         dataDir + "primer-schemes",
     ]
-    if workflow == "medaka":
-        cmd.append("--model")
-        cmd.append("r941_min_high_g351")
 
     if workflow == "clair3":
-        cmd.append("--model")
-        cmd.append("r941_prom_hac_g360+g422")
+        cmd.append("--model r941_prom_hac_g360+g422")
 
     if sampleID in extraFlags[workflow]:
         for flag in extraFlags[workflow][sampleID]:

--- a/tests/minion_validator.py
+++ b/tests/minion_validator.py
@@ -186,7 +186,8 @@ def genCommand(sampleID, workflow):
     ]
 
     if workflow == "clair3":
-        cmd.append("--model r941_prom_hac_g360+g422")
+        cmd.append("--model")
+        cmd.append("r941_prom_hac_g360+g422")
 
     if sampleID in extraFlags[workflow]:
         for flag in extraFlags[workflow][sampleID]:
@@ -251,6 +252,7 @@ def runner(workflow, sampleID):
         args = parser.parse_args(cmd)
     except SystemExit:
         sys.stderr.write("failed to parse valid command for `artic minion`")
+        assert False
 
     # run the minion pipeline
     try:


### PR DESCRIPTION
Made in response to artic-network/fieldbioinformatics/issues/144.

Currently align_trim prints a large amount of information about primer trimming to the file: `{args.sample}.alignreport.er` which also includes raised exceptions which can lead to failures where the exception is hidden from the end user.

This PR makes align_trim far less verbose by default so the stderr can be displayed during pipeline execution, any information previously stored in `{args.sample}.alignreport.er` is accessible in `{args.sample}.alignreport.csv` in far more detail.

The align_trim commands no longer pipe directly to samtools to ensure any exceptions are clearly displayed.