### PR TITLE
Optimise make depth mask

### DIFF
--- a/artic/make_depth_mask.py
+++ b/artic/make_depth_mask.py
@@ -54,12 +54,17 @@ def collect_depths(bamfile, refName, minDepth, ignoreDeletions, warnRGcov):
     # create the dict to hold the depths for each readgroup
     rgDepths = {rg["ID"]: np.zeros(ref_len, dtype=np.int32) for rg in bamFile.header["RG"]}
 
-    # iterate reads once via fetch — each read's RG tag is looked up a single time
+    # iterate reads once — each read's RG tag is looked up a single time
     # and numpy slice assignment updates all covered positions in C, avoiding the
-    # O(ref_length × coverage) Python loop that pileup() would require
-    for read in bamFile:
-        if read.reference_name != refName:
-            continue
+    # O(ref_length × coverage) Python loop that pileup() would require.
+    # use fetch(refName) when an index is available (faster for multi-contig refs);
+    # fall back to a full sequential scan with reference filtering when no index is present.
+    try:
+        _reads = bamFile.fetch(refName)
+    except ValueError:
+        _reads = (r for r in bamFile if r.reference_name == refName)
+
+    for read in _reads:
         if read.is_unmapped or read.cigartuples is None:
             continue
 

--- a/artic/make_depth_mask.py
+++ b/artic/make_depth_mask.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 from Bio import SeqIO
 import itertools
+import numpy as np
 import os
 import pysam
 import sys
@@ -28,10 +29,10 @@ def collect_depths(bamfile, refName, minDepth, ignoreDeletions, warnRGcov):
 
     Returns
     -------
-    list
+    numpy.ndarray
         Index is the reference position, value is the corresponding coverage depth
     dict
-        Key is readgroup, value is a list of coverage depths where index is the reference position
+        Key is readgroup, value is a numpy array of coverage depths where index is the reference position
     """
     # check the BAM file exists
     if not os.path.exists(bamfile):
@@ -45,77 +46,68 @@ def collect_depths(bamfile, refName, minDepth, ignoreDeletions, warnRGcov):
     if tid == -1:
         raise Exception("bamfile does not contain specified reference (%s)" % refName)
 
+    ref_len = bamFile.get_reference_length(refName)
+
     # create a depth vector to hold the depths at each reference position
-    depths = [0] * bamFile.get_reference_length(refName)
+    depths = np.zeros(ref_len, dtype=np.int32)
 
     # create the dict to hold the depths for each readgroup
-    rgDepths = {}
+    rgDepths = {rg["ID"]: np.zeros(ref_len, dtype=np.int32) for rg in bamFile.header["RG"]}
 
-    # get the read groups and init the depth vectors
-    for rg in bamFile.header["RG"]:
-        rgDepths[rg["ID"]] = [0] * bamFile.get_reference_length(refName)
+    # iterate reads once via fetch — each read's RG tag is looked up a single time
+    # and numpy slice assignment updates all covered positions in C, avoiding the
+    # O(ref_length × coverage) Python loop that pileup() would require
+    for read in bamFile.fetch(refName):
+        if read.is_unmapped or read.cigartuples is None:
+            continue
 
-    # flag to state if BAM file has low readgroup coverage
-    lowRGcov = False
+        rg = read.get_tag("RG")
+        assert rg in rgDepths, "alignment readgroup not in BAM header: %s" % rg
 
-    # vector to keep track of low readgroup coverage regions
-    lowRGvec = []
+        rg_arr = rgDepths[rg]
+        ref_pos = read.reference_start
 
-    # generate the pileup
-    for pileupcolumn in bamFile.pileup(
-        refName,
-        start=0,
-        stop=bamFile.get_reference_length(refName),
-        max_depth=100000000,
-        truncate=False,
-        min_base_quality=0,
-    ):
-        # process the pileup column
-        for pileupread in pileupcolumn.pileups:
-
-            # get the read group for this pileup read and check it's in the BAM header
-            rg = pileupread.alignment.get_tag("RG")
-            assert rg in rgDepths, "alignment readgroup not in BAM header: %s" % rg
-
-            # process the pileup read
-            if pileupread.is_refskip:
-                continue
-
-            if pileupread.is_del:
+        for op, length in read.cigartuples:
+            if op in (0, 7, 8):
+                # M, =, X — match/mismatch: consumes reference, count depth
+                depths[ref_pos:ref_pos + length] += 1
+                rg_arr[ref_pos:ref_pos + length] += 1
+                ref_pos += length
+            elif op == 2:
+                # D — deletion: consumes reference, count unless ignoreDeletions
                 if not ignoreDeletions:
-                    depths[pileupcolumn.pos] += 1
-                    rgDepths[rg][pileupcolumn.pos] += 1
+                    depths[ref_pos:ref_pos + length] += 1
+                    rg_arr[ref_pos:ref_pos + length] += 1
+                ref_pos += length
+            elif op == 3:
+                # N — reference skip (splice/amplicon gap): consumes reference, do not count
+                ref_pos += length
+            elif op in (1, 4, 5, 6):
+                # I, S, H, P — do not consume reference, skip
+                pass
 
-            elif not pileupread.is_del:
-                depths[pileupcolumn.pos] += 1
-                rgDepths[rg][pileupcolumn.pos] += 1
+    # vectorized post-processing: apply depth masking and per-RG coverage check
 
-            else:
-                raise Exception("unhandled pileup read encountered")
+    # stack all per-RG arrays into a 2D matrix for vectorized operations
+    rg_matrix = np.stack(list(rgDepths.values()))  # shape: (num_rg, ref_len)
 
-        # if final depth for pileup column < minDepth, report 0 and update the mask_vector
-        if depths[pileupcolumn.pos] < minDepth:
-            depths[pileupcolumn.pos] = 0
+    # mask positions where combined depth < minDepth
+    low_combined = depths < minDepth
+    depths[low_combined] = 0
 
-        # if pileupcolumn depth is okay, check that at least one of the readgroups > minDepth
-        else:
-            rgCovCheck = 0
-            for rg in rgDepths:
-                if rgDepths[rg][pileupcolumn.pos] >= minDepth:
-                    rgCovCheck += 1
-            if rgCovCheck == 0:
+    # mask positions where combined depth is adequate but no single RG has >= minDepth
+    any_rg_ok = np.any(rg_matrix >= minDepth, axis=0)
+    low_rg_mask = ~low_combined & ~any_rg_ok
 
-                # mask the region if it has low coverage in all readgroups
-                depths[pileupcolumn.pos] = 0
-
-                # also record the region so that we can report it if requested
-                lowRGcov = True
-                lowRGvec.append(pileupcolumn.pos)
+    lowRGcov = False
+    lowRGvec = []
+    if np.any(low_rg_mask):
+        depths[low_rg_mask] = 0
+        lowRGvec = np.where(low_rg_mask)[0].tolist()
+        lowRGcov = True
 
     # if requested, warn if there are regions with low readgroup coverage that pass the combined depth threshold
     if warnRGcov and lowRGcov:
-
-        # get the regions and print warning
         regions = list(intervals_extract(lowRGvec))
         sys.stderr.write(
             "alignment has unmasked regions where individual readgroup depth < {}: {}\n".format(
@@ -171,10 +163,7 @@ def go(args):
                 fh.close()
 
         # create a mask_vector that records reference positions where depth < minDepth
-        mask_vector = []
-        for pos, depth in enumerate(depths):
-            if depth == 0:
-                mask_vector.append(pos)
+        mask_vector = np.where(depths == 0)[0].tolist()
 
         # get the intervals from the mask_vector
         intervals = list(intervals_extract(mask_vector))

--- a/artic/make_depth_mask.py
+++ b/artic/make_depth_mask.py
@@ -57,7 +57,9 @@ def collect_depths(bamfile, refName, minDepth, ignoreDeletions, warnRGcov):
     # iterate reads once via fetch — each read's RG tag is looked up a single time
     # and numpy slice assignment updates all covered positions in C, avoiding the
     # O(ref_length × coverage) Python loop that pileup() would require
-    for read in bamFile.fetch(refName):
+    for read in bamFile.fetch():
+        if read.reference_name != refName:
+            continue
         if read.is_unmapped or read.cigartuples is None:
             continue
 

--- a/artic/make_depth_mask.py
+++ b/artic/make_depth_mask.py
@@ -57,7 +57,7 @@ def collect_depths(bamfile, refName, minDepth, ignoreDeletions, warnRGcov):
     # iterate reads once via fetch — each read's RG tag is looked up a single time
     # and numpy slice assignment updates all covered positions in C, avoiding the
     # O(ref_length × coverage) Python loop that pileup() would require
-    for read in bamFile.fetch():
+    for read in bamFile:
         if read.reference_name != refName:
             continue
         if read.is_unmapped or read.cigartuples is None:

--- a/tests/make_depth_mask_unit_test.py
+++ b/tests/make_depth_mask_unit_test.py
@@ -1,0 +1,204 @@
+"""
+Unit tests for artic.make_depth_mask.collect_depths.
+
+Synthetic BAM files are generated programmatically with pysam into pytest's
+tmp_path — no large test files are committed to the repo.
+"""
+import numpy as np
+import pytest
+import pysam
+
+from artic.make_depth_mask import collect_depths
+
+
+REF_NAME = "ref"
+REF_LEN = 200
+
+
+def _make_segment(header, qname, rg, ref_start, cigartuples):
+    """Build a minimal mapped AlignedSegment."""
+    # Only CIGAR ops that consume query bases contribute to query_sequence length
+    qlen = sum(length for op, length in cigartuples if op in (0, 1, 4, 7, 8))
+    seg = pysam.AlignedSegment(header)
+    seg.query_name = qname
+    seg.query_sequence = "A" * qlen
+    seg.flag = 0
+    seg.reference_id = 0
+    seg.reference_start = ref_start
+    seg.mapping_quality = 60
+    seg.cigartuples = cigartuples
+    seg.query_qualities = pysam.qualitystring_to_array("I" * qlen)
+    seg.set_tag("RG", rg)
+    return seg
+
+
+@pytest.fixture
+def make_bam(tmp_path):
+    """
+    Fixture factory.  Call as:
+        path = make_bam(read_groups, reads, indexed=True)
+
+    read_groups : list of RG ID strings
+    reads       : list of (query_name, rg_id, ref_start, cigartuples)
+    indexed     : if True, sort + index the BAM
+    """
+    def _factory(read_groups, reads, indexed=True):
+        header = pysam.AlignmentHeader.from_dict({
+            "HD": {"VN": "1.6"},
+            "SQ": [{"SN": REF_NAME, "LN": REF_LEN}],
+            "RG": [{"ID": rg} for rg in read_groups],
+        })
+        unsorted = str(tmp_path / "unsorted.bam")
+        path = str(tmp_path / "test.bam")
+        with pysam.AlignmentFile(unsorted, "wb", header=header) as bam:
+            for qname, rg, ref_start, cigar in reads:
+                bam.write(_make_segment(header, qname, rg, ref_start, cigar))
+        pysam.sort("-o", path, unsorted)
+        if indexed:
+            pysam.index(path)
+        return path
+
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_basic_depth_single_rg(make_bam):
+    """A single 50M read in one RG should give depth=1 for positions 0-49."""
+    path = make_bam(
+        read_groups=["pool1"],
+        reads=[("r1", "pool1", 0, [(0, 50)])],  # 50M
+    )
+    depths, rg_depths = collect_depths(path, REF_NAME, minDepth=1, ignoreDeletions=False, warnRGcov=False)
+
+    assert np.all(depths[0:50] == 1), "covered positions should have depth 1"
+    assert np.all(depths[50:] == 0), "uncovered positions should have depth 0"
+    assert np.array_equal(depths, rg_depths["pool1"]), "single RG should match combined depths"
+
+
+def test_min_depth_masking(make_bam):
+    """Positions with depth < minDepth should be zeroed out."""
+    path = make_bam(
+        read_groups=["pool1"],
+        reads=[("r1", "pool1", 0, [(0, 50)])],  # depth=1 everywhere
+    )
+    depths, _ = collect_depths(path, REF_NAME, minDepth=2, ignoreDeletions=False, warnRGcov=False)
+
+    assert np.all(depths == 0), "depth=1 < minDepth=2 so all positions should be masked"
+
+
+def test_two_rgs_non_overlapping(make_bam):
+    """Two RGs with non-overlapping reads; each RG's depth array should only cover its own region."""
+    path = make_bam(
+        read_groups=["pool1", "pool2"],
+        reads=[
+            ("r1", "pool1", 0,  [(0, 50)]),   # pool1 covers 0-49
+            ("r2", "pool2", 50, [(0, 50)]),   # pool2 covers 50-99
+        ],
+    )
+    depths, rg_depths = collect_depths(path, REF_NAME, minDepth=1, ignoreDeletions=False, warnRGcov=False)
+
+    assert np.all(depths[0:50] == 1)
+    assert np.all(depths[50:100] == 1)
+    assert np.all(depths[100:] == 0)
+    assert np.all(rg_depths["pool1"][0:50] == 1)
+    assert np.all(rg_depths["pool1"][50:] == 0)
+    assert np.all(rg_depths["pool2"][0:50] == 0)
+    assert np.all(rg_depths["pool2"][50:100] == 1)
+
+
+def test_low_rg_coverage_masking(make_bam):
+    """
+    Combined depth >= minDepth but NO individual RG reaches minDepth —
+    positions should be masked to 0.
+    pool1: 1 read (depth=1), pool2: 1 read (depth=1) → combined=2, minDepth=2
+    Each RG has depth 1 < 2, so the position should be masked.
+    """
+    path = make_bam(
+        read_groups=["pool1", "pool2"],
+        reads=[
+            ("r1", "pool1", 0, [(0, 50)]),
+            ("r2", "pool2", 0, [(0, 50)]),
+        ],
+    )
+    depths, _ = collect_depths(path, REF_NAME, minDepth=2, ignoreDeletions=False, warnRGcov=False)
+
+    assert np.all(depths[0:50] == 0), (
+        "combined depth passes minDepth but neither RG individually does — should be masked"
+    )
+
+
+def test_deletion_counted_by_default(make_bam):
+    """With ignoreDeletions=False, D-op positions contribute to depth."""
+    # cigar: 25M 5D 25M  →  ref positions 0-54, deletion at 25-29
+    path = make_bam(
+        read_groups=["pool1"],
+        reads=[("r1", "pool1", 0, [(0, 25), (2, 5), (0, 25)])],
+    )
+    depths, _ = collect_depths(path, REF_NAME, minDepth=1, ignoreDeletions=False, warnRGcov=False)
+
+    assert np.all(depths[0:55] == 1), "deletion positions should be counted when ignoreDeletions=False"
+    assert np.all(depths[55:] == 0)
+
+
+def test_deletion_ignored(make_bam):
+    """With ignoreDeletions=True, D-op positions should have depth 0."""
+    path = make_bam(
+        read_groups=["pool1"],
+        reads=[("r1", "pool1", 0, [(0, 25), (2, 5), (0, 25)])],
+    )
+    depths, _ = collect_depths(path, REF_NAME, minDepth=1, ignoreDeletions=True, warnRGcov=False)
+
+    assert np.all(depths[0:25] == 1)
+    assert np.all(depths[25:30] == 0), "deletion positions should be 0 when ignoreDeletions=True"
+    assert np.all(depths[30:55] == 1)
+    assert np.all(depths[55:] == 0)
+
+
+def test_reference_skip_not_counted(make_bam):
+    """N-op (reference skip) positions should not contribute to depth."""
+    # cigar: 25M 10N 25M  →  ref positions 0-59, skip at 25-34
+    path = make_bam(
+        read_groups=["pool1"],
+        reads=[("r1", "pool1", 0, [(0, 25), (3, 10), (0, 25)])],
+    )
+    depths, _ = collect_depths(path, REF_NAME, minDepth=1, ignoreDeletions=False, warnRGcov=False)
+
+    assert np.all(depths[0:25] == 1)
+    assert np.all(depths[25:35] == 0), "N-op positions should not be counted"
+    assert np.all(depths[35:60] == 1)
+    assert np.all(depths[60:] == 0)
+
+
+def test_indexed_and_unindexed_give_same_result(make_bam, tmp_path):
+    """fetch(refName) and sequential scan fallback should produce identical output."""
+    reads = [
+        ("r1", "pool1", 0,  [(0, 50)]),
+        ("r2", "pool2", 25, [(0, 50)]),
+    ]
+    rgs = ["pool1", "pool2"]
+
+    indexed_bam = make_bam(rgs, reads, indexed=True)
+
+    # build an unindexed copy by sorting without calling pysam.index
+    unindexed_bam = str(tmp_path / "unindexed.bam")
+    header = pysam.AlignmentHeader.from_dict({
+        "HD": {"VN": "1.6"},
+        "SQ": [{"SN": REF_NAME, "LN": REF_LEN}],
+        "RG": [{"ID": rg} for rg in rgs],
+    })
+    unsorted = str(tmp_path / "unsorted2.bam")
+    with pysam.AlignmentFile(unsorted, "wb", header=header) as bam:
+        for qname, rg, ref_start, cigar in reads:
+            bam.write(_make_segment(header, qname, rg, ref_start, cigar))
+    pysam.sort("-o", unindexed_bam, unsorted)
+    # deliberately NOT indexing
+
+    depths_idx, rg_idx = collect_depths(indexed_bam,   REF_NAME, minDepth=1, ignoreDeletions=False, warnRGcov=False)
+    depths_raw, rg_raw = collect_depths(unindexed_bam, REF_NAME, minDepth=1, ignoreDeletions=False, warnRGcov=False)
+
+    assert np.array_equal(depths_idx, depths_raw), "indexed and unindexed should give the same combined depths"
+    for rg in rgs:
+        assert np.array_equal(rg_idx[rg], rg_raw[rg]), f"RG {rg} depths differ between indexed and unindexed"


### PR DESCRIPTION
This pull request significantly refactors the `collect_depths` function in `artic/make_depth_mask.py` to use efficient numpy-based operations for depth calculation and masking, replacing the previous Python loop and pileup-based approach. It also introduces a comprehensive unit test suite with synthetic BAM generation to ensure correctness across various scenarios.

**Performance and correctness improvements:**

* Refactored `collect_depths` to use numpy arrays for depth and per-readgroup coverage, replacing Python lists and pileup iteration. This enables efficient vectorized operations and greatly improves performance, especially for large BAM files.
* Changed the return type of `collect_depths` from lists to numpy arrays for both combined and per-readgroup depths, updating the docstring accordingly.
* Updated masking logic to use numpy vectorized masking for positions with low combined or per-readgroup depth, improving clarity and speed. [[1]](diffhunk://#diff-76c52933ad04916a5dedbe223ae15fb5e4dcbaca56f4414cc8193b41daea4de4R49-L118) [[2]](diffhunk://#diff-76c52933ad04916a5dedbe223ae15fb5e4dcbaca56f4414cc8193b41daea4de4L174-R173)

**Testing improvements:**

* Added a new unit test suite `tests/make_depth_mask_unit_test.py` that programmatically generates synthetic BAM files with pysam to test a wide range of depth calculation and masking behaviors, including edge cases for CIGAR operations and BAM indexing.

**Minor improvements:**

* Updated the mask vector creation in `go` to use numpy operations for efficiency.
* Added the numpy import to `make_depth_mask.py`.